### PR TITLE
Revised example to use the default 'local' ivy repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ A simple model to be published to the local Ivy cache.
 
 ## Build & Publish Locally
 1. Clone this repo
-2. Make sure you have Ant and Ivy installed correctly; if not follow the steps below under the **Ant/Ivy Setup** section
+2. Make sure you have Ant installed correctly
 3. In a terminal, navigate to the cloned directory
-4. Run `ant local-publish`
-5. Inspect your local Ivy cache (typically `~/.ivy2/cache/hotmeatballsoup/fizzbuzz-model/`) to verify it has been published
+4. Run `ant publish`
+5. Inspect your local Ivy repository (`~/.ivy2/local/hotmeatballsoup/fizzbuzz-model`) to verify it has been published
 6. Now, go to the [**fizzbuzz-app**](https://github.com/hotmeatballsoup/fizzbuzz-app) that depends on this model and follow the instructions in its README
 
 ## Ant/Ivy Setup
@@ -23,14 +23,6 @@ If nothing shows up, navigate to this cloned repo and run `ant clean`. If you ge
 Now verify that `echo $ANT_HOME` produces successful output.
 
 ### Ivy
-Run a `ls -al` on your Ant lib directory like so:
 
-> ls -al $ANT_HOME/lib
+Ivy will be automatically installed by the build if it does not exist.
 
-Look for an Ivy jar, such as `ivy-2.4.0.jar`. If you don't see one, run
-
-1. `curl -O "http://www.webhostingjams.com/mirror/apache//ant/ivy/2.4.0/apache-ivy-2.4.0-bin-with-deps.tar.gz"`
-2. `tar -xvf apache-ivy-2.4.0-bin-with-deps.tar.gz`
-3. Copy all the jars inside of it to `$ANT_HOME/lib`
-
-If something gets botched in that process, you can just manually download the archive directly from Ivy's [download site](http://ant.apache.org/ivy/download.cgi), just make sure to get the archive "with deps".

--- a/build.xml
+++ b/build.xml
@@ -1,22 +1,14 @@
 <project name="fizzbuzz-model" default="publish" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant" >
-    <taskdef name="ivy-configure" classname="org.apache.ivy.ant.IvyConfigure" />
-    <taskdef name="ivy-resolve" classname="org.apache.ivy.ant.IvyResolve" />
-    <taskdef name="ivy-retrieve" classname="org.apache.ivy.ant.IvyRetrieve" />
-    <taskdef name="ivy-cleancache" classname="org.apache.ivy.ant.IvyCleanCache" />
 
-    <ivy:settings file="ivy-settings.xml" id="ivy.instance" />
+    <property name="target.release" value="1.0"/>
 
-    <path id="build.class.path">
-        <fileset dir="lib/main">
-            <include name="**/*.jar" />
-        </fileset>
-    </path>
+    <available classname="org.apache.ivy.Main" property="ivy.installed"/> 
 
-    <target name="clean">
-        <delete dir="dist" quiet="true" />
-        <delete dir="build" quiet="true" />
-        <delete dir="gen" quiet="true" />
-  	</target>
+    <target name="install-ivy" unless="ivy.installed">
+        <mkdir dir="${user.home}/.ant/lib"/>
+        <get dest="${user.home}/.ant/lib/ivy.jar" src="http://search.maven.org/remotecontent?filepath=org/apache/ivy/ivy/2.4.0/ivy-2.4.0.jar"/>
+        <fail message="Ivy has been installed. Run the build again"/>
+    </target>
 
     <target name="init" depends="clean">
     		<mkdir dir="build/main" />
@@ -24,33 +16,44 @@
     		<mkdir dir="gen" />
   	</target>
 
-    <target name="resolve">
-  		<delete>
-  			<fileset dir="lib/main" includes="*.jar" />
-  		</delete>
-  		<ivy:resolve file="ivy.xml" conf="compile" />
-  		<ivy:retrieve pattern="lib/main/[artifact]-[type]-[revision].[ext]" conf="compile" />
+    <target name="resolve" depends="install-ivy">
+  		<ivy:resolve/>
+
+      <ivy:cachepath pathid="compile.path" conf="compile"/>
+      <ivy:cachepath pathid="test.path"    conf="test"/>
   	</target>
 
     <target name="compile" depends="init,resolve">
-        <javac destdir="build/main">
-            <src path="src/main/java" />
-            <classpath>
-                <path refid="build.class.path" />
-                <pathelement path="build/main" />
-            </classpath>
-        </javac>
+        <javac srcdir="src/main/java" destdir="build/main" includeantruntime="false" debug="true" classpathref="compile.path"/>
     </target>
 
     <target name="dist" depends="clean,compile">
-        <jar jarfile="dist/fizzbuz-model.jar" basedir="build/main" />
+        <jar jarfile="dist/fizzbuzz-model.jar" basedir="build/main" />
   	</target>
 
-    <target name="local-publish" depends="clean,dist">
-        <copy file="dist/fizzbuz-model.jar" tofile="dist/fizzbuzz-model-1.0.0-SNAPSHOT.jar" />
-        <ivy:makepom ivyfile="ivy.xml" pomfile="dist/fizzbuzz-model-1.0.0-SNAPSHOT.pom" />
-        <ivy:publish resolver="local" pubrevision="1.0.0-SNAPSHOT" >
-            <artifacts pattern="dist/[artifact]-[revision].[ext]" />
+    <target name="publish" depends="clean,dist">
+ 
+        <!-- Determine build number from previously published revisions -->
+        <ivy:buildnumber resolver="local" organisation="${ivy.organisation}" module="${ivy.module}" revision="${target.release}"/>
+
+        <!-- Resolve ivy dependencies and create a Maven POM file -->
+        <ivy:deliver deliverpattern="dist/ivy.xml" pubrevision="${ivy.new.revision}" status="release"/>
+        <ivy:makepom ivyfile="dist/ivy.xml" pomfile="dist/fizzbuzz-model.pom" />
+
+        <!-- Publish the local repo. Defaults to ~/.ivy2/local -->
+        <ivy:publish resolver="local" pubrevision="${ivy.new.revision}" >
+            <artifacts pattern="dist/[artifact].[ext]" />
         </ivy:publish>
   	</target>
+
+   <target name="clean">
+        <delete dir="dist" quiet="true" />
+        <delete dir="build" quiet="true" />
+        <delete dir="gen" quiet="true" />
+  	</target>
+
+   <target name="clean-all" depends="clean">
+     <ivy:cleancache/>
+  	</target>
+
 </project>

--- a/ivy-settings.xml
+++ b/ivy-settings.xml
@@ -1,16 +1,9 @@
 <ivysettings>
-    <settings defaultResolver="defResolver" />
-    <latest-strategies>
-        <latest-lexico />
-    </latest-strategies>
-
+    <settings defaultResolver="mavenRepos" />
     <resolvers>
-        <chain name="defResolver">
-            <ibiblio name="maven2" m2compatible="true" usepoms="true" />
-            <ibiblio name="spring" m2compatible="true" usepoms="true" />
+        <chain name="mavenRepos">
+            <ibiblio name="maven2" m2compatible="true"/>
+            <ibiblio name="spring" m2compatible="true"/>
         </chain>
-        <filesystem name="local" checkmodified="true">
-            <artifact pattern="${user.home}/.ivy2/cache/[organisation]/[artifact]/[revision]/[artifact]-[revision].[ext]" />
-        </filesystem>
     </resolvers>
 </ivysettings>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,16 +1,18 @@
 <ivy-module version="2.0" xmlns:xsi="http://www.w3.org/2001/XmlSchema-instance">
     <info organisation="hotmeatballsoup" module="fizzbuzz-model" revision="1.0" />
-    <configurations defaultconfmapping="default">
+    <configurations>
         <conf name="compile" description="provides compile-time deps" />
-        <conf name="runtime" description="provides runtime deps" />
-        <conf name="test" description="test deps" />
-        <conf name="publish" description="publish" />
-        <conf name="default" description="default" />
+        <conf name="runtime" description="provides runtime deps" extends="compile" />
+        <conf name="test"    description="test deps" extends="runtime" />
+        <conf name="master"  description="Used for compliance with Maven repos"/>
+        <conf name="default" description="Used for compliance with Maven repos"/>
     </configurations>
     <publications>
         <artifact name="fizzbuzz-model" type="jar" ext="jar"/>
         <artifact name="fizzbuzz-model" type="pom" ext="pom"/>
     </publications>
     <dependencies>
+        <!-- Test dependencies -->
+        <dependency org="junit" name="junit" rev="latest.release" conf="test->default"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
This PR is in response to a request on Stackoverflow

http://stackoverflow.com/questions/39125953/publishing-to-and-resolving-from-local-ivy-cache-by-example/

You'll notice some extensive rewriting of the build file to add support for ivy. 

1. No need to declare tasks. Just install jar in the expected ANT extension directory
1. Added an install-ivy task to simplify setup
1. Use ivy configurations to manage classpaths directly
1. Use an ivy local directory to publish artefacts which defaults to "~/.ivy/local". 
1. Demonstrates how ivy can calculate the correct build number based on what is already published
1. Demonstrates how ivy can depend on the latest release of a 3rd party dependency like junit, yet still create a properly resolved version number in the POM file.